### PR TITLE
Allow gem to work with Rails 4.1.0

### DIFF
--- a/simple_form_fancy_uploads.gemspec
+++ b/simple_form_fancy_uploads.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 4.0.0"
+  s.add_dependency "rails", ">= 4.0.0"
 
   s.add_dependency "simple_form", "~> 3.0.0"
   s.add_dependency "carrierwave"


### PR DESCRIPTION
I am currently running Rails 4.1.0.rc2, but that version of rails currently does not work with your gem because it is using pessimistic versioning limiting it to only the 4.0 build. I have been using it on Rails 4.1 and have not run into any problems. Thanks!
